### PR TITLE
Error handling fixes

### DIFF
--- a/service/sync_manager.py
+++ b/service/sync_manager.py
@@ -102,7 +102,7 @@ def _synchronise_es_indexes_with_source():
 
         LOGGER.info('Index synchronisation started')
     except Exception as e:
-        LOGGER.error('An error occurred when starting index synchronisation', e)
+        LOGGER.error('An error occurred when starting index synchronisation', exc_info=e)
 
 
 def _trigger_index_synchronisation(index_updater):
@@ -128,7 +128,7 @@ def _synchronise_index_with_source(index_updater):
             "An error occurred when updating elasticsearch using updater '{}'".format(
                 index_updater.id
             ),
-            e
+            exc_info=e
         )
     finally:
         _update_index_updater_status(index_updater, busy=False)

--- a/service/synchroniser.py
+++ b/service/synchroniser.py
@@ -33,25 +33,25 @@ def _bring_index_up_to_date(index_updater):
     while not is_up_to_date_with_source:
         data_page, errors = _populate_index_with_data_page(index_updater)
 
-        if errors:
-            LOGGER.error("Elasticsearch update resulted with errors: {}".format(errors))
-            return False
-        else:
-            LOGGER.info("Updated elasticsearch with page of data. Updater: '{}'".format(
+        # TODO: investigate what types of errors to handle -
+        # I've found 'not found' on deletions and 'conflict' on insert/updates, but they were
+        # only informational - the updates took place
+
+        LOGGER.info("Updated elasticsearch with page of data. Updater: '{}'".format(
+            index_updater.id
+        ))
+
+        if data_page:
+            index_updater.update_status(data_page)
+            LOGGER.info("Updated synchronisation status for updater '{}'".format(
                 index_updater.id
             ))
 
-            if data_page:
-                index_updater.update_status(data_page)
-                LOGGER.info("Updated synchronisation status for updater '{}'".format(
-                    index_updater.id
-                ))
-
-            if len(data_page) < page_size:
-                LOGGER.info("Updater '{}' is up to date with source data store".format(
-                    index_updater.id
-                ))
-                is_up_to_date_with_source = True
+        if len(data_page) < page_size:
+            LOGGER.info("Updater '{}' is up to date with source data store".format(
+                index_updater.id
+            ))
+            is_up_to_date_with_source = True
 
     return True
 

--- a/tests/test_synchroniser.py
+++ b/tests/test_synchroniser.py
@@ -56,27 +56,3 @@ class TestSynchroniser:
 
         assert mock_updater.update_status.mock_calls == [call([title1, title2]), call([title3])]
         assert len(mock_execute_es_actions.mock_calls) == 2
-
-    @mock.patch('service.es_utils.execute_elasticsearch_actions', return_value=(1, ['error']))
-    def test_synchronise_index_with_source_stops_on_elasticsearch_error(
-            self, mock_execute_es_actions):
-
-        synchroniser.page_size = 1
-
-        title1 = MockTitleRegisterData('TTL1', {'register': 'data1'}, datetime.now(), False)
-        title2 = MockTitleRegisterData('TTL2', {'register': 'data2'}, datetime.now(), False)
-
-        mock_updater = MagicMock()
-
-        # There are two pages of data, but we expect only the first one to be processed
-        mock_updater.get_next_source_data_page.side_effect = [[title1], [title2]]
-        mock_updater.prepare_elasticsearch_actions.return_value = [{'update': 'action1'}]
-
-        synchroniser.synchronise_index_with_source(mock_updater, 'index_name1', 'doc_type1')
-
-        assert len(mock_updater.get_next_source_data_page.mock_calls) == 1
-
-        assert mock_updater.prepare_elasticsearch_actions.mock_calls == [call(title1)]
-
-        assert mock_updater.update_status.mock_calls == []
-        assert len(mock_execute_es_actions.mock_calls) == 1


### PR DESCRIPTION
Made the updater log exceptions properly. Also, stopped aborting index update on elasticsearch error results, as the ones I observed are not really errors. Needs investigating, but the feeder doesn't check for the errors, either.
